### PR TITLE
fix(matrix): drive E2EE key lifecycle so echo works in encrypted rooms

### DIFF
--- a/docs/brainstorms/2026-06-16-pluggable-persistence-requirements.md
+++ b/docs/brainstorms/2026-06-16-pluggable-persistence-requirements.md
@@ -1,0 +1,255 @@
+---
+date: 2026-06-16
+topic: pluggable-persistence
+---
+
+# Pluggable Persistence + Model Neutrality
+
+## Summary
+
+Make persistence database-agnostic by splitting the clean persistence layer into
+concern-scoped stores — identity, global message records, per-chat storage — each
+bound to a backend through config. An operator picks ZODB, SQLite, both, or none
+per connector. Shared keys keep records joinable across backends, and ZODB plus
+SQLite both ship so a second, structurally different backend proves the seam.
+
+---
+
+## Problem Frame
+
+ia.cecil's stated approach is composability via runtime-loadable modules: any
+combination of platform, community, and experiment assembled without forking. The
+connector layer realizes this — each connector declares its own activation rule and
+loads dynamically, a failing one is marked down without stopping siblings. Persistence
+never got the same treatment. The clean layer (`src/iacecil/controllers/persistence/neutral.py`,
+`src/iacecil/controllers/persistence/chat_store.py`) hardcodes ZODB: `Person` inherits
+`persistent.Persistent`, records live in `BTrees.OOBTree`, and `dispatch` calls free
+functions directly.
+
+ZODB itself is not the pain. The pain is that the architecture offers no seam — there
+is no way to run a different database for a data-handling step, no way to add a backend
+alongside or in place of ZODB, and no way to let one bot's connector store to SQLite
+while another stays on ZODB. The goal is the seam, with ZODB kept as one valid backend.
+
+---
+
+## Key Decisions
+
+**Concern-scoped stores, not one backend interface.** The clean layer splits into three
+stores by data concern: an identity store (`resolve_person`, `merge_persons`), a message
+store (global neutral records / `persist_envelope`), and a chat store (per-chat
+`store_message`). Each binds to its own backend. This matches the operator model "a
+different database for each step of data handling" and lets identity stay authoritative
+while message and chat fan out.
+
+**Identity is single-authority; message and chat are per-connector.** A Person maps
+multiple `(platform, native_id)` pairs to one human and is cross-platform by definition,
+so the identity store is one global backend — per-connector identity would fork the same
+human into divergent records. Backend selection per connector governs the message and
+chat stores only.
+
+**Referential consistency, not transactional.** The same `person_id` and `msg_id` appear
+identically in every store that holds a given record, so records stay joinable across
+backends. Each store still writes independently — a failure in one is isolated and logged,
+preserving the current per-step `try/except` in `dispatch`. No cross-backend atomic commit.
+
+**Shared keys minted once at the authoritative layer.** `person_id` is minted by the
+identity store's get-or-create. `msg_id` is minted once above the fan-out and passed to
+every active message/chat backend, which stores the id it is given. Fan-out backends are
+pure sinks that never mint their own ids — otherwise a "both"-mode message would carry a
+different `msg_id` in each store and stop being joinable.
+
+**Models drop `persistent.Persistent`.** `Person` becomes a plain dataclass like
+`Envelope` already is; the message record stays a plain dict (it already is one). Models
+are defined once and mapped per-backend by that backend's serializer. The boundary returns
+ids and plain values only, never live persistent objects.
+
+**ZODB and SQLite both ship in v1.** They are literal per-connector config choices, so a
+working second backend is part of the deliverable. An ABC with one implementation would
+not prove agnosticism.
+
+---
+
+## Requirements
+
+### Backend contract
+
+R1. A backend contract exists per concern — identity, message, chat — exposing only the
+operations the clean layer's call sites exercise today: identity = `resolve_person`,
+`merge_persons`; message = `persist_envelope`; chat = `store_message`; plus lifecycle
+(`close`). The contract is write-only.
+
+R2. Every contract method is async at the boundary and returns ids or plain values, never
+a live backend object. Blocking I/O (fsync, file open) runs off the event loop so a
+backend never stalls the shared connector loop.
+
+R3. A backend declares its own activation the way connectors do (a self-declared
+`is_active` / `required_keys` rule), and is discovered dynamically by name from config —
+no per-backend branching in the loader.
+
+### Backend selection and fan-out
+
+R4. An operator selects ZODB, SQLite, both, or none for a connector's message and chat
+stores through config, mirroring how a connector's config section carries its credentials.
+
+R5. A concern binds to an ordered list of backends. The first is authoritative (mints
+shared keys, serves any future reads); the rest are mirror sinks. A single backend is a
+list of one; "both" is a list of two; "none" is empty.
+
+R6. When several backends are active for a concern, the same record is written to each with
+identical shared keys (`person_id`, `msg_id`).
+
+R7. "none" for a connector skips all persistence for that connector's traffic, including
+identity resolution — nothing is written and no `person_id` is minted.
+
+### Consistency and isolation
+
+R8. The identity store is a single global authoritative backend across all connectors; it
+mints `person_id` and owns the `(platform, native_id) -> person_id` mapping.
+
+R9. Each store write is isolated: a failure in one store (or one fan-out backend) is logged
+and does not skip the other stores or block command dispatch. Identity never forks; a mirror
+store may lag.
+
+R10. The dual-schema invariant is preserved across backends — the global message store keys
+the platform value as `platform`, the per-chat store keys it as `connector`. No backend
+unifies the two without migrating both stores and their readers.
+
+### Models
+
+R11. `Person` is a plain dataclass with no ZODB base class; mappings are a plain collection.
+The message record is a plain dict / typed record. Neither model imports `persistent`,
+`BTrees`, or `transaction`.
+
+R12. Each backend owns a serializer mapping the neutral models to and from its native form.
+The ZODB backend wraps them at write time; SQLite maps to rows.
+
+### Backends
+
+R13. A ZODB backend reproduces today's `neutral.py` / `chat_store.py` behavior — conflict
+retry, per-chat path sanitization, native-id dedupe, LRU of open handles — behind the
+contract, so a bot defaulting to ZODB is unchanged.
+
+R14. A SQLite backend implements the same contract: get-or-create (upsert) for identity,
+`INSERT OR IGNORE` on a unique native-id index for dedupe, file-based storage. It runs with
+WAL mode and a busy_timeout to absorb single-writer contention.
+
+### Config and tests
+
+R15. Backend selection lives in a parallel `persistence:` config section in `BotConfig` /
+`instance/` configs, not in `config.py` default values beyond a neutral default section. The
+section carries the global identity backend and a per-connector map of backend lists
+(`persistence.connectors.<name>: [zodb, sqlite]` for both, `[sqlite]` for one, `[]` for none).
+It sits alongside `plugins:` / `telegram:` / `discord:`, mirroring the `plugins` enable/disable
+precedent. The default keeps every existing bot on ZODB.
+
+R16. The test-isolation seam stays as cheap as today's — backends are repointable to a temp
+location per test, and the autouse isolation fixture in `tests/conftest.py` keeps working.
+
+---
+
+## Acceptance Examples
+
+AE1. **Covers R5, R6, R8.** Connector configured "both." A message arrives. Identity store
+(global ZODB) mints `person_id=uuid-A`. The message store fans out one record to ZODB and one
+to SQLite, both carrying `person_id=uuid-A` and the same `msg_id`. The two records are joinable.
+
+AE2. **Covers R7.** Connector configured "none." A message arrives. No `person_id` is minted,
+no message or chat record is written, command dispatch still runs.
+
+AE3. **Covers R9.** Connector configured "both." The SQLite write raises. The ZODB record is
+still written, the error is logged, identity is unchanged, and dispatch continues.
+
+AE4. **Covers R13.** Bot with no persistence config. Behavior is identical to today: ZODB
+stores, conflict retry, dedupe, sanitized chat paths.
+
+---
+
+## Scope Boundaries
+
+**Deferred for later:**
+- Reads / queries. The clean layer is write-only in production today — neither `neutral.py`
+  nor `chat_store.py` defines a read function, and the admin/plots routes read from legacy
+  `zodb_orm`. A query contract becomes a future concern-slot when a real reader exists, so it
+  is not invented now against legacy negative-slice semantics.
+- `merge_persons` is part of the identity contract but has no production caller (tests and
+  maintenance only); it ships but is not a driver of the design.
+- Additional backends (SQLAlchemy + Alembic for server/Postgres, document store) — the
+  contract is shaped to admit them, but only ZODB and SQLite ship now.
+- Migration of legacy `instance/zodb/` data. Legacy data is disposable; a one-time export is
+  out of scope here.
+
+**Outside this effort's identity:**
+- Decoupling legacy `zodb_orm` (~15 call sites across plugins, furhat, web routes, pickling
+  aiogram objects). It stays frozen behind its current surface — a separate epic that must not
+  be coupled to the clean-layer seam.
+- Transactional / distributed-commit consistency across backends, and any reconciliation/repair
+  pass. Referential consistency is the chosen guarantee.
+
+---
+
+## Dependencies / Assumptions
+
+- The clean layer has exactly one production write consumer: `ConnectorManager.dispatch`
+  (`src/iacecil/connectors/__init__.py:163,168,172,214,215`). The write-path blast radius is
+  that one module. Verified.
+- `flask-sqlalchemy` is already a Pipfile dependency and `config.py` carries commented
+  `sqlalchemy_database_uri` lines — latent SQL intent, but the chosen SQLite backend uses
+  stdlib `sqlite3` (or `aiosqlite`), not necessarily SQLAlchemy.
+- The connector pattern (`src/iacecil/connectors/base.py`, `ConnectorManager._load_connectors`)
+  is the template for backend registration and failure isolation. Assumed stable.
+- Telegram-origin envelopes are persisted but not command-dispatched (legacy aiogram owns
+  Telegram replies); the persistence seam does not change that arbitration.
+
+---
+
+## Outstanding Questions
+
+**Deferred to planning:**
+- Whether the SQLite backend uses stdlib `sqlite3` behind `asyncio.to_thread` or `aiosqlite`.
+- Exact table shape for the SQLite backend (people / mappings / messages / chat).
+- Whether the three concern contracts are three ABCs or one ABC with a concern tag.
+
+---
+
+## Sources / Research
+
+- `docs/ideation/2026-06-16-pluggable-persistence-and-model-neutrality.md` — origin ideation,
+  ranked ideas and rejected alternatives.
+- `src/iacecil/controllers/persistence/neutral.py` — identity + global message store, `Person(persistent.Persistent)`, dual-schema note, conflict retry.
+- `src/iacecil/controllers/persistence/chat_store.py` — per-chat store, path sanitization, native-id dedupe, LRU handles.
+- `src/iacecil/connectors/__init__.py:155-217` — `dispatch`, the sole write consumer; `person_id` mint + stamp flow.
+- `src/iacecil/connectors/base.py` — `BaseConnector` activation/registration template.
+- `tests/conftest.py` — autouse persistence isolation fixture the seam must preserve.
+- `CONCEPTS.md` — Person, Neutral Record, Chat Store, Connector vocabulary.
+
+---
+
+## Deferred / Open Questions
+
+### From 2026-06-16 review
+
+- **`none` / global-identity contradiction (P1, coherence).** R7 and AE2 say a "none"
+  connector mints no `person_id`, but Key Decisions and R8 say identity is one global
+  authoritative store across all connectors. Resolve whether "none" skips only message/chat
+  persistence (identity resolution still runs) or gates `resolve_person` at dispatch. Pairs
+  with the gate-location FYI below.
+- **`both`/fan-out may exceed the goal (P1, product-lens + scope-guardian).** Ordered backend
+  lists (R5), identical-key fan-out (R6), mirror-lag isolation (R9), and AE1/AE3 exist only to
+  run two live backends at once, a scenario no operator need in the doc explains. Decide: name
+  the scenario (e.g. zero-downtime migration) or descope `both` to a later slice and ship v1 as
+  single-backend-per-concern substitution. The two entries below dissolve if `both` is descoped.
+  - **Shared `msg_id` vs dedupe skip (P1, adversarial).** Chat store returns `None` on native-id
+    dedupe while the message store always writes; one `msg_id` across both sinks leaves a global
+    record with no matching chat record, silently breaking AE1 joinability.
+  - **Message vs chat dedupe asymmetry (P1, adversarial).** Only the chat store dedupes on
+    native-id today; the global store never does. R6's "same record, identical keys" is impossible
+    for duplicates, yet R13 demands ZODB reproduce today's asymmetric behavior.
+- **"Referential consistency" undefined for the dangling direction (P2, adversarial).** Identity
+  can commit while message writes fail (R9 isolation), leaving a `person_id` with no referencing
+  records. Define the guarantee: keys are byte-identical in any store that holds the record,
+  presence is not guaranteed, orphan `person_id`s are accepted and unrepaired.
+- **"Write-only contract" vs read-modify-write (P2, adversarial).** R1 says "write-only," but
+  `resolve_person` is get-or-create and R5 says the authoritative backend "serves any future
+  reads." Reframe as "write-and-resolve, no query API" — identity read-modify-write, message/chat
+  append-only, no ad-hoc query surface.

--- a/docs/connectors/matrix.md
+++ b/docs/connectors/matrix.md
@@ -1,0 +1,48 @@
+# Matrix Connector Configuration
+
+The Matrix connector allows ia.cecil to interact with Matrix homeservers (like matrix.org).
+
+## Prerequisites
+
+1.  **Homeserver URL**: The URL of your Matrix homeserver (e.g., `https://matrix.org`).
+2.  **Access Token**: Preferred for security. You can obtain one from your Matrix client (like Element) or via login.
+3.  **User ID / Password**: Alternatively, you can provide a User ID (e.g., `@bot:matrix.org`) and password for bootstrap login.
+
+## Configuration
+
+Add a `matrix` section to your bot configuration file in `instance/bots/<bot_name>.py`.
+
+```python
+class MyBotConfig(DefaultBotConfig):
+    matrix: dict = {
+        'homeserver': 'https://matrix.org',
+        'token': 'YOUR_MATRIX_ACCESS_TOKEN',
+        # Optional: if using password login instead of token
+        # 'user': '@bot:matrix.org',
+        # 'password': 'your_password',
+        'channels': [
+            '!roomid:matrix.org', # Authorized Room ID 1
+            '!anotherroom:matrix.org', # Authorized Room ID 2
+        ]
+    }
+```
+
+### Authorization Rules
+
+- **1:1 Direct Messages (DMs)**: The bot always responds to DMs (rooms with 2 or fewer members).
+- **Group Rooms**: The bot only responds in rooms listed in the `channels` configuration.
+- **Plaintext Only**: Currently, this connector only supports plaintext rooms. Encrypted rooms are detected and ignored with a warning.
+
+## Features
+
+- **Sync Persistence**: The bot saves its sync token to `instance/matrix/` to avoid re-processing old messages on restart.
+- **Message Chunking**: Automatically splits messages exceeding 16000 characters (configurable via `MAX_TEXT`).
+- **Self-Echo**: The bot filters out its own messages.
+
+## Running
+
+The Matrix connector is compatible with the `connectors_v3` runner.
+
+```bash
+python -m iacecil connectors_v3
+```

--- a/docs/connectors/xmpp.md
+++ b/docs/connectors/xmpp.md
@@ -1,0 +1,45 @@
+# XMPP Connector Configuration
+
+The XMPP connector allows ia.cecil to interact with XMPP servers (like Jabber, Conversations.im) for both direct messages and chatrooms (MUC).
+
+## Prerequisites
+
+1.  **JID**: A Jabber ID (e.g., `bot@example.com`).
+2.  **Password**: The password for the JID.
+3.  **XMPP Server**: A server that supports XEP-0045 (Multi-User Chat) if you plan to use chatrooms.
+
+## Configuration
+
+Add an `xmpp` section to your bot configuration file in `instance/bots/<bot_name>.py`.
+
+```python
+class MyBotConfig(DefaultBotConfig):
+    xmpp: dict = {
+        'jid': 'bot@example.com',
+        'password': 'your_password',
+        'channels': [
+            'room1@conference.example.com', # Authorized MUC JID 1
+            'room2@conference.example.com', # Authorized MUC JID 2
+        ]
+    }
+```
+
+### Authorization Rules
+
+- **Direct Messages (chat/normal)**: The bot always responds to DMs.
+- **Chatrooms (groupchat)**: The bot only responds in chatrooms listed in the `channels` configuration.
+- **Self-Echo**: The bot automatically filters out its own messages in chatrooms to prevent infinite loops.
+
+## Features
+
+- **MUC Support**: Automatically joins configured chatrooms on connection.
+- **Message Chunking**: Automatically splits messages exceeding 4000 characters (configurable via `MAX_TEXT`).
+- **Authorization**: Mirrors the Discord connector's channel-based authorization logic.
+
+## Running
+
+The XMPP connector is compatible with the `connectors_v3` runner.
+
+```bash
+python -m iacecil connectors_v3
+```

--- a/docs/instance.example/bots/default.py
+++ b/docs/instance.example/bots/default.py
@@ -205,6 +205,9 @@ class DefaultBotConfig(BaseSettings):
         ## also enable the "Message Content Intent" toggle on the Bot
         ## page or every inbound message arrives with empty text.
         'token': None,
+        'channels': [
+            '123456789012345678',
+        ],
     } # discord
     matrix: dict = {
         'homeserver': None, # e.g. "https://matrix.org"

--- a/docs/instance.example/bots/default.py
+++ b/docs/instance.example/bots/default.py
@@ -215,6 +215,7 @@ class DefaultBotConfig(BaseSettings):
         'token': None,
         'user': None, # e.g. "@mybot:matrix.org" (password login only)
         'password': None,
+        'channels': [],
     } # matrix
     furhat: dict = {
         'bot': "garbage",

--- a/docs/instance.example/bots/default.py
+++ b/docs/instance.example/bots/default.py
@@ -205,9 +205,7 @@ class DefaultBotConfig(BaseSettings):
         ## also enable the "Message Content Intent" toggle on the Bot
         ## page or every inbound message arrives with empty text.
         'token': None,
-        'channels': [
-            '123456789012345678',
-        ],
+        'channels': [],
     } # discord
     matrix: dict = {
         'homeserver': None, # e.g. "https://matrix.org"
@@ -265,4 +263,8 @@ class DefaultBotConfig(BaseSettings):
             'model': "deepseek-r1:1.5b",
         }, # ollama
     } # deepseek
-    xmpp: dict = {'jid': '', 'password': ''}
+    xmpp: dict = {
+        'jid': '',
+        'password': '',
+        'channels': [],
+    }

--- a/docs/instance.example/bots/matehackersbot.py
+++ b/docs/instance.example/bots/matehackersbot.py
@@ -19,7 +19,6 @@ default_config = DefaultBotConfig()
 class BotConfig(BaseSettings):
     coinmarketcap: dict = default_config.coinmarketcap
     deepseek: dict = default_config.deepseek
-    discord: dict = default_config.discord
     donate: dict = default_config.donate
     furhat: dict = default_config.furhat
     info: dict = default_config.info
@@ -30,10 +29,31 @@ class BotConfig(BaseSettings):
     timezone: str = default_config.timezone
     tropixel: dict = default_config.tropixel
     web3: dict = default_config.web3
-    xmpp: dict = default_config.xmpp
-    matrix: dict = default_config.matrix
-    mastodon: dict = default_config.mastodon
-    loopback: dict = default_config.loopback
+
+    discord: dict = dict(
+        token = "YOUR_DISCORD_TOKEN",
+        channels = [
+            "123456789012345678",
+        ],
+    ) # discord
+    xmpp: dict = dict(
+        jid = "bot@example.com",
+        password = "your_password",
+        channels = [
+            "room@conference.example.com",
+        ],
+    ) # xmpp
+    matrix: dict = dict(
+        homeserver = "https://matrix.org",
+        token = "YOUR_ACCESS_TOKEN",
+    ) # matrix
+    mastodon: dict = dict(
+        api_base_url = "https://mastodon.social",
+        access_token = "YOUR_ACCESS_TOKEN",
+    ) # mastodon
+    loopback: dict = dict(
+        enabled = False,
+    ) # loopback
     
     personalidade: str = "matebot"
     plugins: dict = dict(

--- a/docs/instance.example/bots/matehackersbot.py
+++ b/docs/instance.example/bots/matehackersbot.py
@@ -30,6 +30,10 @@ class BotConfig(BaseSettings):
     timezone: str = default_config.timezone
     tropixel: dict = default_config.tropixel
     web3: dict = default_config.web3
+    xmpp: dict = default_config.xmpp
+    matrix: dict = default_config.matrix
+    mastodon: dict = default_config.mastodon
+    loopback: dict = default_config.loopback
     
     personalidade: str = "matebot"
     plugins: dict = dict(

--- a/docs/plans/2026-06-16-002-feat-xmpp-muc-echo-plan.md
+++ b/docs/plans/2026-06-16-002-feat-xmpp-muc-echo-plan.md
@@ -1,0 +1,88 @@
+# XMPP MUC Echo Support Plan
+
+**Target repo:** iacecil
+**Date:** 2026-06-16
+
+## Problem Frame
+
+The XMPP bot currently only responds to direct messages (`chat` or `normal` message types). The user wants the bot to support Multi-User Chat (MUC) chatrooms and run the `echo` plugin there, similar to how the Discord connector currently filters and replies in authorized channels. 
+
+The `echo` plugin is already platform-agnostic (it registers a default envelope handler that echoes text). The issue is that the XMPP connector does not load the XEP-0045 plugin for MUC support, does not join configured channels, does not dispatch `groupchat` messages, and does not authorize or route messages back to MUCs correctly.
+
+---
+
+## Requirements
+
+- R1. The XMPP connector must load the XEP-0045 (MUC) plugin upon connection.
+- R2. The XMPP connector must automatically join the channels specified in its `channels` configuration list on session start.
+- R3. The connector must dispatch incoming `groupchat` messages to the manager.
+- R4. The connector must not dispatch its own messages in a groupchat (avoiding infinite echo loops).
+- R5. The connector must restrict responses to DMs and explicitly authorized `channels` (same as Discord).
+- R6. Outbound replies must use the correct message type (`groupchat` for chatrooms, `chat` for DMs).
+
+---
+
+## Scope Boundaries
+
+- This plan only implements MUC support for the XMPP connector.
+- Advanced MUC administration (kicking, banning, role management) is deferred to follow-up work.
+- It relies on the existing default echo handler in `echo.py` without modifying it.
+
+---
+
+## Key Technical Decisions
+
+- **XEP-0045 Registration:** `slixmpp` provides native MUC support via the `xep_0045` plugin. We will register it in `Connector.connect()`.
+- **Authorization Check:** We will override `is_authorized()` in `xmpp.Connector`, mimicking the logic in `discord.py` so that only DMs and explicitly configured MUCs are allowed to process commands or echoes.
+- **Message Type Routing:** We will inspect the incoming envelope's raw message type (`groupchat` vs `chat`) when sending a response in `Connector.send()`, ensuring the reply has the correct `mtype`.
+- **Own Message Filtering:** In `groupchat`, our own messages appear with `msg['mucnick']` or `msg['from'].resource` matching the nickname we used to join. We will use `msg['from'].resource == self.boundjid.user` or the plugin's `ourNicks` dict to filter them.
+
+---
+
+## Implementation Units
+
+- U1. **XMPP Connector MUC Support**
+
+**Goal:** Allow XMPP connector to join MUCs, authorize channels, and dispatch/reply to `groupchat` messages.
+
+**Requirements:** R1, R2, R3, R4, R5, R6
+
+**Files:**
+- Modify: `src/iacecil/connectors/xmpp.py`
+- Test: `tests/test_xmpp.py`
+
+**Approach:**
+- In `Connector.connect()`, add `self.bot.register_plugin('xep_0045')`.
+- In `XMPPBot.start()`, iterate over `self.connector.config.get('channels', [])` and call `self.plugin['xep_0045'].join_muc(room_jid, self.boundjid.user)`.
+- In `XMPPBot.message()`, allow `msg['type'] in ('chat', 'normal', 'groupchat')`.
+- Add own-message filtering for groupchats: `if msg['type'] == 'groupchat' and msg['from'].resource == self.boundjid.user: return`.
+- In `Connector.send()`, determine outbound `mtype` from `envelope.raw['type']` if available, otherwise default to `'chat'`.
+- Override `is_authorized(self, envelope: Envelope) -> bool` in `Connector`: if `envelope.raw['type'] != 'groupchat'`, return `True`. Otherwise, return `envelope.conversation_ref` is in configured channels.
+
+**Patterns to follow:**
+- `discord.py`'s `is_authorized` logic for channel filtering.
+
+**Test scenarios:**
+- Happy path: Bot receives `groupchat` message from another user -> dispatches Envelope with `platform='xmpp'`.
+- Edge case: Bot receives `groupchat` message from itself (same nick) -> ignores it.
+- Happy path: `Connector.is_authorized` returns True for DM.
+- Happy path: `Connector.is_authorized` returns True for MUC listed in config.
+- Error path: `Connector.is_authorized` returns False for MUC not listed in config.
+- Happy path: `Connector.send` uses `mtype='groupchat'` when Envelope originates from a `groupchat` message.
+
+**Verification:**
+- XMPP connector connects, joins configured MUCs, and echoes messages from other users in those MUCs while ignoring its own messages and unauthorized MUCs.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** Enhances the XMPP platform capabilities without altering the core envelope or manager flow.
+- **Unchanged invariants:** `echo.py` and other plugins remain unaware of platform-specific message types; they just receive an `Envelope`.
+
+---
+
+## Operational Notes
+
+- Operators will need to ensure their Slixmpp installation supports `xep_0045` (it does by default).
+- Operators must list desired MUC JIDs in the `channels` list under the `xmpp` section of `instance/bots/<botname>.py`.

--- a/docs/plans/2026-06-16-003-feat-matrix-connector-channels-plan.md
+++ b/docs/plans/2026-06-16-003-feat-matrix-connector-channels-plan.md
@@ -1,0 +1,50 @@
+# Create Technical Plan
+
+## Feature Description
+
+Add channel configuration support to the Matrix connector, making it consistent with Discord and XMPP. The echo plugin is used to test. Need to update bot config and the instance example.
+
+## Requirements
+
+- R1. Matrix configuration should include a `channels` key (list of authorized room IDs).
+- R2. Matrix connector should only reply to messages in rooms listed in `channels`, or in 1:1 DMs (rooms with <= 2 members).
+- R3. Default configurations in `src/iacecil/config.py` and `docs/instance.example/bots/default.py` must be updated to include the new `channels` key for Matrix.
+
+## Scope Boundaries
+
+- Only the Matrix connector is affected.
+- Testing will be done using the `echo` plugin.
+
+## Key Technical Decisions
+
+- **DM Detection in Matrix**: Unlike Discord (`message.guild`) or XMPP (`message.type == 'groupchat'`), Matrix events don't explicitly carry the DM vs group state in the text message event itself. We will use `self.client.rooms.get(envelope.conversation_ref)` to access the room state and check its member count (`len(room.users) <= 2`) to identify 1:1 DMs and always authorize them.
+
+## Implementation Units
+
+- U1. **Config Updates**
+  **Goal:** Add the `channels` key to Matrix configurations.
+  **Files:**
+  - Modify: `src/iacecil/config.py`
+  - Modify: `docs/instance.example/bots/default.py`
+  **Approach:** Add `'channels': [],` to the `matrix` dict.
+  **Test scenarios:**
+  - Happy path: Matrix configuration loads with an empty `channels` list by default.
+
+- U2. **Matrix Connector `is_authorized`**
+  **Goal:** Filter incoming Matrix messages based on authorized channels.
+  **Files:**
+  - Modify: `src/iacecil/connectors/matrix.py`
+  - Test: `tests/test_matrix.py`
+  **Approach:**
+  - Implement `is_authorized(self, envelope) -> bool` on `MatrixConnector`.
+  - Fetch the room using `self.client.rooms.get(envelope.conversation_ref)`.
+  - Return `True` if `len(room.users) <= 2` (DM).
+  - Otherwise, return `True` if `envelope.conversation_ref` is in `self.config.get('channels')`.
+  - Return `False` otherwise.
+  **Test scenarios:**
+  - Happy path: Message in an authorized room ID is authorized.
+  - Edge case: Message in a DM (<= 2 users) is authorized even if not in `channels`.
+  - Error path: Message in an unauthorized group room (> 2 users) is not authorized.
+
+## Verification
+- Echo plugin will echo messages in authorized Matrix rooms or DMs, and ignore messages in unauthorized Matrix rooms.

--- a/docs/plans/2026-06-16-004-fix-matrix-e2ee-key-lifecycle-plan.md
+++ b/docs/plans/2026-06-16-004-fix-matrix-e2ee-key-lifecycle-plan.md
@@ -1,0 +1,137 @@
+---
+title: "fix: Matrix E2EE key lifecycle so echo works in encrypted rooms"
+date: 2026-06-16
+type: fix
+depth: standard
+origin: user request ("matrix encryption + echo plugin still broken since v0.83.2")
+---
+
+# fix: Matrix E2EE key lifecycle so echo works in encrypted rooms
+
+## Summary
+
+The Matrix connector still cannot echo in encrypted rooms despite the prior
+agent's fixes (E2EE dependency auto-detect, store dir creation, sync
+`load_store()`, manual `decrypt_event` call). The remaining gap is the
+**key-management lifecycle**: a manual `client.sync()` loop must call
+`keys_upload()` / `keys_query()` itself, and must send with
+`ignore_unverified_devices=True`. `AsyncClient.sync_forever()` does this
+automatically; our hand-rolled loop in `matrix.py` does not. Without it the
+bot never publishes its device keys, so no sender can share a Megolm session
+key with the bot — every encrypted message arrives as an undecryptable
+`MegolmEvent`, `_on_event` sees `body=None`, and the echo default-handler is
+never reached.
+
+## Problem Frame
+
+- Symptom: logs show `Room <id> has an encrypted message that could not be
+  decrypted`; echo plugin never replies in encrypted Matrix rooms.
+- Verified environment (`.venv`): `matrix-nio==0.25.2`, `nio.crypto.ENCRYPTION_ENABLED=True`, `python-olm` importable, `load_store` is **sync**. So E2EE is fully supported at runtime — the blocker is logic, not deps.
+- Confirmed via nio source: `AsyncClient.sync_forever` runs `keys_upload()`
+  when `should_upload_keys` and `keys_query()` when `should_query_keys`. The
+  manual loop in `listen()` runs neither.
+- Confirmed: `AsyncClient.room_send(ignore_unverified_devices=False)` by
+  default — sending into an encrypted room with any unverified device raises,
+  so even a decrypted message would fail to echo back.
+
+## Root Cause
+
+`src/iacecil/connectors/matrix.py` drives its own `sync()` loop instead of
+`sync_forever()`, but never replicates the key lifecycle `sync_forever`
+performs. Two concrete defects:
+
+1. **No `keys_upload` / `keys_query`** — device keys + one-time keys are never
+   published; the bot is invisible to senders' key-sharing, so it can never
+   obtain Megolm session keys → decryption always fails.
+2. **`send()` omits `ignore_unverified_devices=True`** — replies into encrypted
+   rooms raise `OlmUnverifiedDeviceError`.
+
+## Key Technical Decisions
+
+- **KTD1 — Replicate the lifecycle inline, keep the manual loop.** Do not
+  switch to `sync_forever`; the manual loop is load-bearing for token
+  persistence, fresh-sync suppression, and backoff. Add the same key calls
+  `sync_forever` makes.
+- **KTD2 — `ignore_unverified_devices=True` on both `room_send` and any group
+  session share.** This is a bot with no UI to do interactive device
+  verification; trust-on-first-use is the only workable posture. `room_send`
+  already shares the group session internally, so no explicit
+  `share_group_session` call is needed — passing the flag through is enough.
+- **KTD3 — Guard all key calls behind `getattr`/`should_*` and the existing
+  `e2e_supported` path** so plaintext-only mode (no libolm) is unaffected and
+  no `AttributeError` fires when `self.client.olm` is absent.
+
+## Implementation Units
+
+### U1. Upload device keys after store load in `connect()`
+
+**Goal:** Publish the bot's device + one-time keys once the encryption store is
+loaded, so senders can establish Olm sessions and share Megolm keys.
+
+**Files:** `src/iacecil/connectors/matrix.py`
+
+**Approach:** After the existing `load_store()` block, if encryption is active
+and `self.client.should_upload_keys`, `await self.client.keys_upload()`. Wrap
+in try/except → warn-and-continue (key upload failure must not brick startup;
+plaintext rooms still work).
+
+**Patterns to follow:** mirror the existing `load_store` try/except warning
+style already in `connect()`.
+
+**Test scenarios:**
+- Encryption active + `should_upload_keys=True` → `keys_upload` awaited once.
+- `keys_upload` raises → warning logged, `connect()` still completes, `running=True`.
+- Plaintext mode (no olm) → `keys_upload` never called (no AttributeError).
+
+### U2. Run key maintenance each sync iteration in `listen()`
+
+**Goal:** Replenish one-time keys and track device-list changes on every
+successful sync, exactly as `sync_forever` does.
+
+**Files:** `src/iacecil/connectors/matrix.py`
+
+**Approach:** In the loop, after a successful sync (`next_batch` obtained,
+retry state reset), before/after event dispatch: if
+`getattr(self.client, 'olm', None)` then `if self.client.should_upload_keys:
+await self.client.keys_upload()` and `if self.client.should_query_keys: await
+self.client.keys_query()`. Failures here are logged and swallowed — they must
+not break the sync loop or trip the backoff counter.
+
+**Test scenarios:**
+- `should_query_keys=True` after sync → `keys_query` awaited.
+- `should_upload_keys=True` after sync → `keys_upload` awaited.
+- key call raises → logged, loop continues to next sync, `failures` not incremented.
+- Plaintext mode (`self.client.olm` is None/absent) → neither called.
+
+### U3. Send with `ignore_unverified_devices=True`
+
+**Goal:** Allow echo replies to be encrypted and delivered into encrypted rooms
+without manual device verification.
+
+**Files:** `src/iacecil/connectors/matrix.py`
+
+**Approach:** In `send()`, pass `ignore_unverified_devices=True` to
+`self.client.room_send(...)`. Harmless for unencrypted rooms (flag ignored).
+
+**Test scenarios:**
+- `send()` calls `room_send` with `ignore_unverified_devices=True`.
+- Multi-chunk text → flag passed on every chunk.
+
+## Verification
+
+- Unit tests in `tests/test_matrix.py` cover U1–U3 with a mocked `client`
+  exposing `should_upload_keys`, `should_query_keys`, `keys_upload`,
+  `keys_query`, `room_send`, `olm`.
+- Manual: against a real homeserver, a NEW message in an encrypted room (sent
+  after the bot has uploaded keys) decrypts and the echo reply appears.
+  Pre-existing messages sent before first key upload remain undecryptable —
+  expected, not a regression.
+
+## Scope Boundaries
+
+In scope: key upload/query lifecycle + verified-device send flag.
+
+### Deferred to Follow-Up Work
+- Interactive / emoji device verification (TOFU is sufficient for a bot).
+- Key backup / cross-signing.
+- Re-decrypting historical messages received before first key upload.

--- a/docs/solutions/integration-issues/matrix-e2ee-decryption-fix-2026-06-16.md
+++ b/docs/solutions/integration-issues/matrix-e2ee-decryption-fix-2026-06-16.md
@@ -1,0 +1,101 @@
+---
+title: "Matrix E2EE decryption: Fix for missing dependencies, store directory, and manual decryption loop"
+date: 2026-06-16
+category: docs/solutions/integration-issues
+module: src/iacecil/connectors/matrix.py
+problem_type: integration_issue
+component: tooling
+severity: high
+symptoms:
+  - "Hard crash on startup: 'ImportError: No module named libolm'"
+  - "Database error: 'unable to open database file' for client.db"
+  - "Async mismatch: 'NoneType' object cannot be used in 'await' expression (for load_store)"
+  - "Messages in encrypted rooms appear as 'Encrypted message' or empty text"
+root_cause: incomplete_setup
+resolution_type: code_fix
+tags:
+  - matrix
+  - e2ee
+  - matrix-nio
+  - encryption
+  - libolm
+  - sqlite
+---
+
+# Matrix E2EE decryption: Fix for missing dependencies, store directory, and manual decryption loop
+
+## Problem
+The Matrix connector failed to decrypt messages in encrypted rooms due to a combination of missing host dependencies, uninitialized filesystem paths, and missing explicit decryption calls in the custom event loop. This blocked the "Echo everywhere" feature from working on encrypted Matrix channels.
+
+## Symptoms
+- **Hard Crash**: The bot failed to start if `encryption: True` was set because `libolm` (the C library for Matrix encryption) was missing from the host system.
+- **SQLite Error**: `sqlite3.OperationalError: unable to open database file` when the bot attempted to create its encryption store because the parent directory `/home/user/.iacecil/matrix/store/` did not exist.
+- **Message Visibility**: Messages received in encrypted rooms were captured as "Encrypted message" or empty strings because the connector didn't explicitly call the decryption method on incoming events.
+- **Async Errors**: `TypeError` or `NoneType` errors when calling `client.load_store()` if treated as synchronous when the installed `matrix-nio` version expects it to be awaited.
+
+## What Didn't Work
+- **Automatic Decryption**: Assuming `matrix-nio` decrypts events automatically in a manual sync loop. It doesn't; you must manually trigger decryption for each encrypted event.
+- **Default Store Path**: Leaving the store path to the library default, which often points to locations the bot doesn't have permission to write to or that don't exist by default.
+
+## Solution
+The fix required ensuring host-level dependencies were present, creating the store directory structure, and updating the event processing loop to handle decryption explicitly.
+
+### 1. Host Dependency (libolm)
+Matrix E2EE requires the `libolm` C library.
+```bash
+sudo apt-get install libolm-dev  # Ubuntu/Debian
+```
+
+### 2. Store Initialization
+Ensure the directory exists before the client attempts to open the SQLite database.
+
+```python
+## src/iacecil/connectors/matrix.py
+import os
+store_path = self.config.get('store_path', 'instance/matrix/store')
+os.makedirs(store_path, exist_ok=True)
+
+# Use AsyncStore for E2EE
+from nio import AsyncClient, AsyncClientConfig
+client_config = AsyncClientConfig(store_sync_diff=True)
+client = AsyncClient(homeserver, user_id, store_path=store_path, config=client_config)
+
+# load_store MUST be awaited in modern nio
+await client.load_store()
+```
+
+### 3. Explicit Decryption Loop
+When using a custom sync loop (rather than `client.sync_forever`), encrypted events must be decrypted manually.
+
+```python
+## In the sync loop:
+for room_id, room in response.rooms.invite.items():
+    # ... handle invites ...
+
+for room_id, room in response.rooms.join.items():
+    for event in room.ephemeral:
+        # ... handle typing ...
+    
+    for event in room.timeline.events:
+        if isinstance(event, MegolmEvent):
+            # nio needs the room_id context for decryption
+            event.room_id = room_id
+            decrypted_event = client.decrypt_event(event)
+            if isinstance(decrypted_event, RoomMessageText):
+                # Now the event text is readable
+                await self._on_message(room_id, decrypted_event)
+```
+
+## Why This Works
+- **libolm**: Required for the cryptographic primitives of the Megolm and Olm protocols used by Matrix.
+- **AsyncStore**: `matrix-nio` uses a SQLite backend to store session keys. It cannot create directories recursively, so `os.makedirs` is mandatory.
+- **Manual Decryption**: In a manual sync loop, the library provides the raw `MegolmEvent`. Calling `decrypt_event` uses the keys stored in the local database to recover the original plaintext and returns a new event object (e.g., `RoomMessageText`).
+
+## Prevention
+- **Dependency Checks**: Add a startup check for `libolm` availability if encryption is enabled.
+- **Path Guard**: Always use `os.makedirs(..., exist_ok=True)` when initializing connectors that require local persistence.
+- **Version Pinning**: Use `matrix-nio[e2ee]` in `requirements.txt` to ensure the Python-side crypto dependencies are pulled in.
+
+## Related Issues
+- `docs/solutions/build-errors/aiogram-matrix-nio-dependency-conflict-2026-06-13.md`
+- `docs/solutions/design-patterns/blocking-client-asyncio-bridge.md`

--- a/docs/solutions/integration-issues/matrix-e2ee-echo-fix-2026-06-16.md
+++ b/docs/solutions/integration-issues/matrix-e2ee-echo-fix-2026-06-16.md
@@ -1,0 +1,106 @@
+---
+title: Matrix Connector E2EE Decryption and Configuration Fixes
+date: 2026-06-16
+category: docs/solutions/integration-issues/
+module: connectors.matrix
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - "Connector crash: 'Encryption is enabled in the client configuration but dependencies for E2E encryption aren't installed'"
+  - "Connector crash: 'unable to open database file' during SQLite store initialization"
+  - "Connector crash: 'object NoneType can't be used in 'await' expression' (load_store is sync)"
+  - "Bot fails to echo: 'Room <id> has an encrypted message that could not be decrypted'"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - matrix
+  - e2ee
+  - nio
+  - decryption
+  - sqlite
+---
+
+# Matrix Connector E2EE Decryption and Configuration Fixes
+
+## Problem
+The Matrix connector was unable to echo messages in encrypted rooms due to multiple layers of integration failures with the `matrix-nio` E2EE implementation, leading to either hard crashes on startup or silent decryption failures.
+
+## Symptoms
+- **Hard crash on start**: `Encryption is enabled in the client configuration but dependencies for E2E encryption aren't installed` (missing `libolm-dev`).
+- **Hard crash on initialization**: `unable to open database file` (missing `instance/matrix/store` directory).
+- **Runtime error**: `object NoneType can't be used in 'await' expression` when calling `await self.client.load_store()`.
+- **Decryption failure**: Logs showing `Room <id> has an encrypted message that could not be decrypted` despite keys being available in the store.
+
+## What Didn't Work
+- **Implicit Encryption**: Assuming that providing a `store_path` to `AsyncClient` would automatically enable E2EE.
+- **Async Assumptions**: Assuming `load_store()` was an asynchronous method because it belongs to `AsyncClient`.
+- **Standard Sync Loop**: Assuming that `nio` would automatically decrypt timeline events in a manual `client.sync()` loop (it only does this in the `sync_forever()` callback-driven mode).
+
+## Solution
+The implementation was updated with the following surgical fixes in `src/iacecil/connectors/matrix.py`:
+
+1.  **Graceful E2EE Fallback**: Added auto-detection for the required C-libraries using `nio.crypto.ENCRYPTION_ENABLED`.
+    ```python
+    try:
+        from nio.crypto import ENCRYPTION_ENABLED as e2e_supported
+    except ImportError:
+        e2e_supported = False
+    
+    if not e2e_supported:
+        logger.warning("Matrix: E2EE dependencies missing. Falling back to plaintext.")
+    ```
+
+2.  **Directory Guard**: Explicitly ensured the SQLite store directory exists before initializing the client.
+    ```python
+    if e2e_supported:
+        os.makedirs(STORE_DIR, mode=0o700, exist_ok=True)
+    ```
+
+3.  **Sync `load_store`**: Removed the `await` keyword from `self.client.load_store()` as it is a synchronous method.
+
+4.  **Explicit Decryption**: Implemented manual decryption for `MegolmEvent`s in the sync loop and ensured the `room_id` is present on the event object.
+    ```python
+    if event.__class__.__name__ == 'MegolmEvent':
+        if not getattr(event, 'room_id', None):
+            event.room_id = room_id
+        decrypted_event = self.client.decrypt_event(event)
+        if decrypted_event:
+            event = decrypted_event
+    ```
+
+5.  **Key lifecycle (the actually-load-bearing fix)**: Steps 1–4 are necessary
+    but **not sufficient**. A manual `sync()` loop must also drive the key
+    lifecycle that `AsyncClient.sync_forever()` performs internally. Without
+    `keys_upload()` the bot's device + one-time keys are never published, so
+    no sender can establish an Olm session to share a Megolm session key —
+    every encrypted event then stays an undecryptable `MegolmEvent` and
+    `decrypt_event()` (step 4) has no key to work with. This is why
+    decryption "still failed" after steps 1–4. Replicate the lifecycle:
+    ```python
+    ## After load_store() in connect():
+    if getattr(self.client, 'olm', None) and self.client.should_upload_keys:
+        await self.client.keys_upload()
+
+    ## After each successful sync() in the loop:
+    if getattr(self.client, 'olm', None):
+        if self.client.should_upload_keys:
+            await self.client.keys_upload()
+        if self.client.should_query_keys:
+            await self.client.keys_query()
+    ```
+    And to *send* into an encrypted room from a headless bot (no interactive
+    verification), pass `ignore_unverified_devices=True` to `room_send` or it
+    raises `OlmUnverifiedDeviceError`.
+
+## Why This Works
+`matrix-nio`'s manual sync mode returns raw `MegolmEvent` objects which represent encrypted ciphertext. Unlike the callback-based `sync_forever`, the manual `sync()` response does not internalize decryption automatically for the returned events. Explicitly calling `decrypt_event()` with the correct `room_id` context allows the `OlmMachine` to retrieve keys from the SQLite store and transform the event into a readable `RoomMessageText` — **but only once the bot has uploaded its own keys (step 5) so a session key was ever shared with it.** `sync_forever` hides this by running `keys_upload`/`keys_query` for you; a hand-rolled loop must do it explicitly. Messages sent before the first `keys_upload` remain undecryptable forever (no key was ever shared); only messages sent afterward decrypt.
+
+## Prevention
+- **Dependency Awareness**: Always check `nio.crypto.ENCRYPTION_ENABLED` before attempting to use E2EE features to prevent crashes in environments without `libolm`.
+- **Manual Sync Logic**: Remember that `client.sync()` requires manual event processing, including decryption of timeline events.
+- **Store Persistence**: Use a stable `device_id` and a persistent `store_path` to avoid "Unknown Device" warnings and redundant verification requests.
+
+## Related Issues
+- `docs/solutions/architecture-patterns/echo-everywhere-multi-connector-architecture-2026-06-12.md`
+- `docs/solutions/design-patterns/blocking-client-asyncio-bridge.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,7 +100,7 @@ mastodon = [
     "Mastodon.py",
 ]
 matrix = [
-    "matrix-nio",
+    "matrix-nio[e2e]",
 ]
 xmpp = [
     "slixmpp",

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,8 @@ anyio==4.13.0
     #   openai
 apscheduler==3.11.1
     # via iacecil (pyproject.toml)
+atomicwrites==1.4.1
+    # via matrix-nio
 attrs==26.1.0
     # via
     #   aiohttp
@@ -61,6 +63,8 @@ brotlipy==0.7.0
     # via iacecil (pyproject.toml)
 btrees==6.4
     # via zodb
+cachetools==5.5.2
+    # via matrix-nio
 certifi==2026.5.20
     # via
     #   aiogram
@@ -73,6 +77,7 @@ cffi==2.0.0
     #   brotlipy
     #   persistent
     #   pycares
+    #   python-olm
 charset-normalizer==3.4.7
     # via requests
 ckzg==2.1.7
@@ -268,6 +273,8 @@ pandas==2.3.3
     #   networkx
 parsimonious==0.10.0
     # via eth-abi
+peewee==3.19.0
+    # via matrix-nio
 persistent==6.7
     # via
     #   btrees
@@ -324,6 +331,8 @@ python-dateutil==2.9.0.post0
     #   pandas
 python-dotenv==1.2.2
     # via pydantic-settings
+python-olm==3.2.16
+    # via matrix-nio
 python-socks==2.8.1
     # via aiohttp-socks
 python-telegram-bot==22.5

--- a/src/iacecil/_version.py
+++ b/src/iacecil/_version.py
@@ -19,5 +19,5 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 MA 02110-1301, USA.
 """
 
-__version__: str = "0.83.1"
+__version__: str = "0.83.2"
 

--- a/src/iacecil/config.py
+++ b/src/iacecil/config.py
@@ -501,6 +501,7 @@ f0123456789abcdef""",
             'token': "",
             'user': "",
             'password': "",
+            'channels': [],
         } # matrix
         mastodon: dict = {
             'api_base_url': "",

--- a/src/iacecil/config.py
+++ b/src/iacecil/config.py
@@ -494,6 +494,7 @@ f0123456789abcdef""",
         } # telegram_v3
         discord: dict = {
             'token': "",
+            'channels': [],
         } # discord
         matrix: dict = {
             'homeserver': "",
@@ -508,6 +509,7 @@ f0123456789abcdef""",
         xmpp: dict = {
             'jid': "",
             'password': "",
+            'channels': [],
         } # xmpp
         loopback: dict = {
             'enabled': False,

--- a/src/iacecil/connectors/__init__.py
+++ b/src/iacecil/connectors/__init__.py
@@ -216,8 +216,10 @@ class ConnectorManager:
                     )
                     return
 
+                logger.debug(f"Handling {envelope.platform} message with {handler!r}")
                 reply_text = await handler(envelope)
                 if reply_text:
+                    logger.debug(f"Handler produced reply: {reply_text!r}")
                     ## Carry person_id (and platform/refs) onto the reply so
                     ## the outbound record links to the triggering person;
                     ## null the inbound-only fields.
@@ -230,10 +232,16 @@ class ConnectorManager:
                         timestamp=None,
                     )
                     if await self.send(reply_env):
+                        logger.debug(f"Sent reply to {envelope.platform}")
                         await persist_envelope(reply_env, direction="out")
                         await store_message(self.bot_id, reply_env, direction="out")
+                    else:
+                        logger.warning(f"Failed to send reply to {envelope.platform}")
+                else:
+                    logger.debug(f"Handler produced NO reply text")
             except Exception as e:
                 logger.error(f"Error handling envelope: {e}")
+                logger.exception(e)
 
     async def _run_connector(self, name, connector):
         try:

--- a/src/iacecil/connectors/matrix.py
+++ b/src/iacecil/connectors/matrix.py
@@ -150,14 +150,28 @@ class Connector(BaseConnector):
         # Use a stable device_id derived from bot_id for E2EE persistence
         device_id = bot_id.upper()[:10]
 
+        # Auto-detect if the required C-libraries (libolm) are installed
+        try:
+            from nio.crypto import ENCRYPTION_ENABLED as e2e_supported
+        except ImportError:
+            e2e_supported = False
+            
+        if not e2e_supported:
+            logger.warning(
+                "Matrix: End-to-End Encryption dependencies (libolm / python-olm) "
+                "are not installed. The connector is falling back to plaintext-only mode. "
+                "To echo in encrypted rooms, install 'libolm-dev' on your system "
+                "and re-run 'pip install -r requirements.txt'."
+            )
+
         client_config = nio.AsyncClientConfig(
-            encryption_enabled=True
+            encryption_enabled=e2e_supported
         )
 
         self.client = nio.AsyncClient(homeserver,
             user=self.config.get('user') or '',
             device_id=device_id,
-            store_path=STORE_DIR,
+            store_path=STORE_DIR if e2e_supported else "",
             config=client_config)
         token = self.config.get('token')
         if token:

--- a/src/iacecil/connectors/matrix.py
+++ b/src/iacecil/connectors/matrix.py
@@ -211,10 +211,23 @@ class Connector(BaseConnector):
         # Load the encryption store if encryption is available
         if hasattr(self.client, 'load_store'):
             try:
-                await self.client.load_store()
+                self.client.load_store()
                 logger.info("Matrix: encryption store loaded.")
             except Exception as e:
                 logger.warning(f"Matrix: could not load encryption store: {e}")
+
+        ## Manual sync loops (unlike sync_forever) must drive the E2EE key
+        ## lifecycle themselves. Publish our device + one-time keys so other
+        ## members can establish an Olm session and share Megolm session keys
+        ## with us. Skip this and the bot stays invisible to key-sharing —
+        ## every encrypted event arrives as an undecryptable MegolmEvent and
+        ## the echo handler never sees any text.
+        if getattr(self.client, 'olm', None) and self.client.should_upload_keys:
+            try:
+                await self.client.keys_upload()
+                logger.info("Matrix: device keys uploaded.")
+            except Exception as e:
+                logger.warning(f"Matrix: initial key upload failed: {e}")
 
         self.next_batch = self._load_token()
         self.running = True
@@ -316,7 +329,21 @@ class Connector(BaseConnector):
             ## Success: reset the retry state.
             failures = 0
             backoff = self.SYNC_BACKOFF_BASE
-            
+
+            ## Drive the key lifecycle exactly as sync_forever would:
+            ## replenish one-time keys (so senders can keep establishing Olm
+            ## sessions with us) and refresh device lists (so we encrypt to
+            ## the right devices). Failures must not break the sync loop or
+            ## trip the backoff counter.
+            if getattr(self.client, 'olm', None):
+                try:
+                    if self.client.should_upload_keys:
+                        await self.client.keys_upload()
+                    if self.client.should_query_keys:
+                        await self.client.keys_query()
+                except Exception as e:
+                    logger.warning(f"Matrix: key maintenance failed: {e}")
+
             # 2. Handle invitations
             invited_rooms = getattr(getattr(response, 'rooms', None), 'invite', None) or {}
             for room_id in invited_rooms:
@@ -345,6 +372,10 @@ class Connector(BaseConnector):
                         # Attempt to decrypt if it's a MegolmEvent
                         if event.__class__.__name__ == 'MegolmEvent':
                             try:
+                                # Ensure room_id is present for the decryptor
+                                if not getattr(event, 'room_id', None):
+                                    event.room_id = room_id
+                                    
                                 decrypted_event = self.client.decrypt_event(event)
                                 if decrypted_event:
                                     event = decrypted_event
@@ -374,10 +405,17 @@ class Connector(BaseConnector):
             logger.warning("Matrix send dropped: client not initialized.")
             return
         for chunk in self._chunks(envelope.text):
+            ## ignore_unverified_devices: a headless bot has no UI to do
+            ## interactive device verification, so trust-on-first-use is the
+            ## only workable posture. Without this, room_send raises
+            ## OlmUnverifiedDeviceError in any encrypted room with an
+            ## unverified member and the echo reply is never delivered. The
+            ## flag is a harmless no-op in unencrypted rooms.
             await self.client.room_send(
                 room_id=envelope.conversation_ref,
                 message_type="m.room.message",
                 content={"msgtype": "m.text", "body": chunk},
+                ignore_unverified_devices=True,
             )
 
     async def disconnect(self):

--- a/src/iacecil/connectors/matrix.py
+++ b/src/iacecil/connectors/matrix.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 
 ## Where matrix sync tokens live; tests patch this to a temp dir.
 TOKEN_DIR = 'instance/matrix'
+STORE_DIR = os.path.join(TOKEN_DIR, 'store')
 
 class Connector(BaseConnector):
     ## Safely under the 64 KiB total event bound, leaving room for
@@ -47,16 +48,43 @@ class Connector(BaseConnector):
         authorized_channels = self.config.get('channels') or []
         room_id = envelope.conversation_ref
         
+        logger.debug(f"Checking authorization for Matrix room {room_id}")
+        logger.debug(f"Authorized channels: {authorized_channels}")
+        
         # 1. Authorize explicitly configured channels
         if str(room_id) in [str(c) for c in authorized_channels]:
+            logger.debug(f"Room {room_id} authorized by ID match.")
             return True
             
-        # 2. Authorize 1:1 DMs (rooms with 2 or fewer members)
+        # 2. Check room state for aliases or member count (DMs)
         if self.client and hasattr(self.client, 'rooms'):
             room = self.client.rooms.get(room_id)
-            if room and len(getattr(room, 'users', {})) <= 2:
-                return True
+            if room:
+                # 2a. Check aliases
+                room_aliases = []
+                if hasattr(room, 'canonical_alias') and room.canonical_alias:
+                    room_aliases.append(room.canonical_alias)
+                # alt_aliases might be available in newer nio versions
+                if hasattr(room, 'alt_aliases'):
+                    room_aliases.extend(room.alt_aliases)
                 
+                logger.debug(f"Room {room_id} aliases: {room_aliases}")
+                for alias in room_aliases:
+                    if str(alias) in [str(c) for c in authorized_channels]:
+                        logger.debug(f"Room {room_id} authorized by alias match: {alias}")
+                        return True
+
+                # 2b. Authorize 1:1 DMs (rooms with 2 or fewer members)
+                # nio.MatrixRoom has member_count; fallback to users dict length
+                member_count = getattr(room, 'member_count', len(getattr(room, 'users', {})))
+                logger.debug(f"Room {room_id} member count: {member_count}")
+                if member_count > 0 and member_count <= 2:
+                    logger.debug(f"Room {room_id} authorized as DM (count={member_count}).")
+                    return True
+            else:
+                logger.debug(f"Room {room_id} not found in client.rooms")
+                
+        logger.debug(f"Room {room_id} NOT authorized.")
         return False
 
     def _token_path(self) -> str:
@@ -115,6 +143,9 @@ class Connector(BaseConnector):
         ## clear error) even when matrix-nio is not installed.
         import nio
         homeserver = self.config.get('homeserver')
+        if homeserver and not (homeserver.startswith('http://') or homeserver.startswith('https://')):
+            homeserver = f"https://{homeserver}"
+            
         self.client = nio.AsyncClient(homeserver,
             user=self.config.get('user') or '')
         token = self.config.get('token')
@@ -134,7 +165,13 @@ class Connector(BaseConnector):
                 " security.")
             response = await self.client.login(self.config.get('password'))
             if not getattr(response, 'access_token', None):
-                raise ConnectionError(f"Matrix login failed: {response!r}")
+                ## To avoid leaking credentials or sensitive object state, we 
+                ## only log the 'status_code' (e.g. M_FORBIDDEN) and 'message' 
+                ## (human-readable description), which are standard Matrix 
+                ## error fields parsed by matrix-nio.
+                status = getattr(response, 'status_code', 'M_UNKNOWN')
+                error_msg = getattr(response, 'message', 'No error message provided by server')
+                raise ConnectionError(f"Matrix login failed: {status} - {error_msg}")
             self.user_id = getattr(response, 'user_id', self.user_id)
         if not self.user_id:
             ## Without our own mxid the self-message guard in _on_event
@@ -148,9 +185,13 @@ class Connector(BaseConnector):
 
     async def _on_event(self, room_id, event):
         sender = getattr(event, 'sender', None)
+        logger.debug(f"Matrix: received event in room {room_id} from {sender}")
+        
         if sender is None or sender == self.user_id:
             ## Own messages echoed back by sync; replying would loop
+            logger.debug(f"Matrix: skipping event from self or None ({sender})")
             return
+        
         body = getattr(event, 'body', None)
         if body is None:
             ## Encrypted or non-message event; plaintext rooms only
@@ -160,7 +201,10 @@ class Connector(BaseConnector):
                 logger.warning(
                     f"Room {room_id} is encrypted; this connector handles"
                     " plaintext rooms only — ignoring its events.")
+            logger.debug(f"Matrix: skipping event without body (class={event.__class__.__name__})")
             return
+            
+        logger.debug(f"Matrix: dispatching message: {body!r}")
         timestamp = getattr(event, 'server_timestamp', None)
         env = Envelope(
             platform='matrix',
@@ -176,6 +220,17 @@ class Connector(BaseConnector):
     async def listen(self):
         if not self.client:
             raise ValueError("Matrix client not initialized")
+        
+        # 1. Join configured channels on startup
+        authorized_channels = self.config.get('channels') or []
+        for channel in authorized_channels:
+            try:
+                # nio.AsyncClient.join can take room ID or alias
+                await self.client.join(channel)
+                logger.info(f"Matrix: joined configured room {channel}")
+            except Exception as e:
+                logger.warning(f"Matrix: could not join configured room {channel}: {e}")
+
         failures = 0
         backoff = self.SYNC_BACKOFF_BASE
         while self.running:
@@ -187,6 +242,7 @@ class Connector(BaseConnector):
                 exc = e
             else:
                 exc = None
+            
             next_batch = getattr(response, 'next_batch', None)
             if not next_batch:
                 ## Error response (or raised exception). A permanent error
@@ -219,9 +275,20 @@ class Connector(BaseConnector):
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 2, self.SYNC_BACKOFF_CAP)
                 continue
+            
             ## Success: reset the retry state.
             failures = 0
             backoff = self.SYNC_BACKOFF_BASE
+            
+            # 2. Handle invitations
+            invited_rooms = getattr(getattr(response, 'rooms', None), 'invite', None) or {}
+            for room_id in invited_rooms:
+                logger.info(f"Matrix: accepting invitation to room {room_id}")
+                try:
+                    await self.client.join(room_id)
+                except Exception as e:
+                    logger.error(f"Matrix: failed to join invited room {room_id}: {e}")
+
             first_sync = self.next_batch is None
             self.next_batch = next_batch
             if first_sync:
@@ -231,6 +298,7 @@ class Connector(BaseConnector):
                 ## File write is blocking; keep it off the event loop.
                 await asyncio.to_thread(self._save_token, next_batch)
                 continue
+            
             rooms = getattr(getattr(response, 'rooms', None), 'join', None) or {}
             for room_id, room_info in rooms.items():
                 events = (getattr(getattr(room_info, 'timeline', None),

--- a/src/iacecil/connectors/matrix.py
+++ b/src/iacecil/connectors/matrix.py
@@ -42,6 +42,23 @@ class Connector(BaseConnector):
         return bool(conf.get('token')
             or (conf.get('user') and conf.get('password')))
 
+    def is_authorized(self, envelope: Envelope) -> bool:
+        """Checks if the envelope's conversation is authorized for replies."""
+        authorized_channels = self.config.get('channels') or []
+        room_id = envelope.conversation_ref
+        
+        # 1. Authorize explicitly configured channels
+        if str(room_id) in [str(c) for c in authorized_channels]:
+            return True
+            
+        # 2. Authorize 1:1 DMs (rooms with 2 or fewer members)
+        if self.client and hasattr(self.client, 'rooms'):
+            room = self.client.rooms.get(room_id)
+            if room and len(getattr(room, 'users', {})) <= 2:
+                return True
+                
+        return False
+
     def _token_path(self) -> str:
         from iacecil.controllers.persistence.path_utils import (
             sanitize_component,

--- a/src/iacecil/connectors/matrix.py
+++ b/src/iacecil/connectors/matrix.py
@@ -342,6 +342,15 @@ class Connector(BaseConnector):
                     'events', None) or [])
                 for event in events:
                     try:
+                        # Attempt to decrypt if it's a MegolmEvent
+                        if event.__class__.__name__ == 'MegolmEvent':
+                            try:
+                                decrypted_event = self.client.decrypt_event(event)
+                                if decrypted_event:
+                                    event = decrypted_event
+                            except Exception as decrypt_exc:
+                                logger.warning(f"Matrix: failed to decrypt event {getattr(event, 'event_id', None)}: {decrypt_exc}")
+                                
                         await self._on_event(room_id, event)
                     except Exception as e:
                         ## One malformed event must not kill the sync loop

--- a/src/iacecil/connectors/matrix.py
+++ b/src/iacecil/connectors/matrix.py
@@ -163,6 +163,8 @@ class Connector(BaseConnector):
                 "To echo in encrypted rooms, install 'libolm-dev' on your system "
                 "and re-run 'pip install -r requirements.txt'."
             )
+        else:
+            os.makedirs(STORE_DIR, mode=0o700, exist_ok=True)
 
         client_config = nio.AsyncClientConfig(
             encryption_enabled=e2e_supported

--- a/src/iacecil/connectors/matrix.py
+++ b/src/iacecil/connectors/matrix.py
@@ -150,10 +150,15 @@ class Connector(BaseConnector):
         # Use a stable device_id derived from bot_id for E2EE persistence
         device_id = bot_id.upper()[:10]
 
+        client_config = nio.AsyncClientConfig(
+            encryption_enabled=True
+        )
+
         self.client = nio.AsyncClient(homeserver,
             user=self.config.get('user') or '',
             device_id=device_id,
-            store_path=STORE_DIR)
+            store_path=STORE_DIR,
+            config=client_config)
         token = self.config.get('token')
         if token:
             self.client.access_token = token

--- a/src/iacecil/connectors/matrix.py
+++ b/src/iacecil/connectors/matrix.py
@@ -146,8 +146,14 @@ class Connector(BaseConnector):
         if homeserver and not (homeserver.startswith('http://') or homeserver.startswith('https://')):
             homeserver = f"https://{homeserver}"
             
+        bot_id = getattr(self.manager, 'bot_id', 'default')
+        # Use a stable device_id derived from bot_id for E2EE persistence
+        device_id = bot_id.upper()[:10]
+
         self.client = nio.AsyncClient(homeserver,
-            user=self.config.get('user') or '')
+            user=self.config.get('user') or '',
+            device_id=device_id,
+            store_path=STORE_DIR)
         token = self.config.get('token')
         if token:
             self.client.access_token = token
@@ -180,6 +186,15 @@ class Connector(BaseConnector):
             raise ConnectionError(
                 "Matrix own user_id unknown after login; refusing to start"
                 " (self-message guard would fail and cause an echo loop).")
+                
+        # Load the encryption store if encryption is available
+        if hasattr(self.client, 'load_store'):
+            try:
+                await self.client.load_store()
+                logger.info("Matrix: encryption store loaded.")
+            except Exception as e:
+                logger.warning(f"Matrix: could not load encryption store: {e}")
+
         self.next_batch = self._load_token()
         self.running = True
 
@@ -194,13 +209,14 @@ class Connector(BaseConnector):
         
         body = getattr(event, 'body', None)
         if body is None:
-            ## Encrypted or non-message event; plaintext rooms only
+            ## Encrypted or non-message event
             if (event.__class__.__name__ == 'MegolmEvent'
                     and room_id not in self._warned_encrypted):
                 self._warned_encrypted.add(room_id)
                 logger.warning(
-                    f"Room {room_id} is encrypted; this connector handles"
-                    " plaintext rooms only — ignoring its events.")
+                    f"Room {room_id} has an encrypted message that could not"
+                    " be decrypted. Check if encryption dependencies are"
+                    " installed and if the bot has been verified.")
             logger.debug(f"Matrix: skipping event without body (class={event.__class__.__name__})")
             return
             

--- a/src/iacecil/connectors/xmpp.py
+++ b/src/iacecil/connectors/xmpp.py
@@ -21,6 +21,9 @@ class XMPPBot(ClientXMPP):
         logger.info(f"XMPP session started as {self.boundjid.full}")
         self.send_presence()
         self.get_roster()
+        channels = self.connector.config.get('channels') or []
+        for channel in channels:
+            self.plugin['xep_0045'].join_muc(channel, self.boundjid.user)
 
     async def on_failure(self, event):
         self.connector.failure = "XMPP authentication or connection failed"
@@ -33,10 +36,14 @@ class XMPPBot(ClientXMPP):
             self.connector.running = False
 
     async def message(self, msg):
-        if msg['from'].full == self.boundjid.full:
+        if msg['type'] == 'groupchat':
+            if msg['from'].resource == self.boundjid.user:
+                return
+        elif msg['from'].full == self.boundjid.full:
             ## Own messages echoed back by server; replying would loop
             return
-        if msg['type'] in ('chat', 'normal'):
+            
+        if msg['type'] in ('chat', 'normal', 'groupchat'):
             stanza_id = str(msg['id']) if msg['id'] else None
             env = Envelope(
                 platform='xmpp',
@@ -59,10 +66,18 @@ class Connector(BaseConnector):
         self.bot = None
         self.failure = None
 
+    def is_authorized(self, envelope: Envelope) -> bool:
+        message = envelope.raw
+        if message is not None and message.get('type') != 'groupchat':
+            return True
+        authorized_channels = self.config.get('channels') or []
+        return str(envelope.conversation_ref) in [str(c) for c in authorized_channels]
+
     async def connect(self):
         jid = self.config.get('jid')
         password = self.config.get('password')
         self.bot = XMPPBot(jid, password, self)
+        self.bot.register_plugin('xep_0045')
         self.bot.connect()
         self.running = True
 
@@ -79,8 +94,12 @@ class Connector(BaseConnector):
         if not self.bot:
             return
 
+        mtype = 'chat'
+        if envelope.raw and envelope.raw.get('type') == 'groupchat':
+            mtype = 'groupchat'
+
         for chunk in self._chunks(envelope.text):
-            self.bot.send_message(mto=envelope.conversation_ref, mbody=chunk, mtype='chat')
+            self.bot.send_message(mto=envelope.conversation_ref, mbody=chunk, mtype=mtype)
 
     async def disconnect(self):
         self.running = False

--- a/src/iacecil/connectors/xmpp.py
+++ b/src/iacecil/connectors/xmpp.py
@@ -16,14 +16,38 @@ class XMPPBot(ClientXMPP):
         self.add_event_handler("failed_auth", self.on_failure)
         self.add_event_handler("connection_failed", self.on_failure)
         self.add_event_handler("disconnected", self.on_disconnected)
+        self.add_event_handler("groupchat_invite", self.on_invite)
 
     async def start(self, event):
         logger.info(f"XMPP session started as {self.boundjid.full}")
         self.send_presence()
         self.get_roster()
-        channels = self.connector.config.get('channels') or []
-        for channel in channels:
+        
+        # 1. Join explicitly configured channels
+        conf_channels = self.connector.config.get('channels') or []
+        to_join = set(conf_channels)
+        
+        # 2. Discover bookmarked rooms (if supported)
+        try:
+            # Note: get_bookmarks() can be a slow XML query; we use a timeout
+            # and ignore errors if the server doesn't support bookmarks.
+            bookmarks = await self.plugin['xep_0048'].get_bookmarks(timeout=5)
+            # Slixmpp XEP-0048 get_bookmarks returns an IQ stanza containing bookmarks
+            for conference in bookmarks['xml'].findall('{storage:bookmarks}conference'):
+                jid = conference.get('jid')
+                if jid:
+                    to_join.add(jid)
+        except Exception as e:
+            logger.debug(f"XMPP bookmark discovery failed: {e}")
+
+        for channel in to_join:
+            logger.info(f"XMPP joining MUC {channel}")
             self.plugin['xep_0045'].join_muc(channel, self.boundjid.user)
+
+    async def on_invite(self, inv):
+        room = inv['from']
+        logger.info(f"XMPP invited to MUC {room} by {inv['inviter']}")
+        self.plugin['xep_0045'].join_muc(room, self.boundjid.user)
 
     async def on_failure(self, event):
         self.connector.failure = "XMPP authentication or connection failed"

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -60,21 +60,37 @@ def test_activation_rules():
 
 def test_is_authorized():
     conn, _ = make_connector()
-    conn.config['channels'] = ['!authorized:example.org']
+    conn.config['channels'] = ['!authorized:example.org', '#alias:example.org']
+    
+    # Mock rooms with different attributes
+    mock_auth = SimpleNamespace(users={'@a', '@b', '@c'}, room_id='!authorized:example.org')
+    
+    mock_alias = SimpleNamespace(users={'@a', '@b', '@c'}, room_id='!other:example.org', 
+                                 canonical_alias='#alias:example.org')
+    
+    mock_dm = SimpleNamespace(users={'@a', '@b'}, room_id='!dm:example.org', member_count=2)
+    
+    mock_unauth = SimpleNamespace(users={'@a', '@b', '@c'}, room_id='!unauth:example.org',
+                                  canonical_alias='#unauth:example.org', member_count=3)
+
     conn.client = SimpleNamespace(rooms={
-        '!authorized:example.org': SimpleNamespace(users={'@a', '@b', '@c'}),
-        '!dm:example.org': SimpleNamespace(users={'@a', '@b'}),
-        '!unauthorized:example.org': SimpleNamespace(users={'@a', '@b', '@c'}),
+        '!authorized:example.org': mock_auth,
+        '!other:example.org': mock_alias,
+        '!dm:example.org': mock_dm,
+        '!unauth:example.org': mock_unauth
     })
     
-    auth_env = Envelope('matrix', '@a', '!authorized:example.org', 'test')
-    assert conn.is_authorized(auth_env) is True
+    # 1. Match by ID
+    assert conn.is_authorized(Envelope('matrix', '@a', '!authorized:example.org', 't')) is True
     
-    dm_env = Envelope('matrix', '@a', '!dm:example.org', 'test')
-    assert conn.is_authorized(dm_env) is True
+    # 2. Match by Alias
+    assert conn.is_authorized(Envelope('matrix', '@a', '!other:example.org', 't')) is True
     
-    unauth_env = Envelope('matrix', '@a', '!unauthorized:example.org', 'test')
-    assert conn.is_authorized(unauth_env) is False
+    # 3. Match DM (member_count)
+    assert conn.is_authorized(Envelope('matrix', '@a', '!dm:example.org', 't')) is True
+    
+    # 4. No match
+    assert conn.is_authorized(Envelope('matrix', '@a', '!unauth:example.org', 't')) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -283,6 +283,87 @@ async def test_send_chunks_under_event_bound():
 
 
 @pytest.mark.asyncio
+async def test_send_ignores_unverified_devices():
+    """Replies into encrypted rooms must pass ignore_unverified_devices so a
+    headless bot (no interactive verification) can still deliver them."""
+    conn, _ = make_connector()
+    conn.client = SimpleNamespace(room_send=AsyncMock())
+    await conn.send(Envelope('matrix', 'u', '!room:example.org', 'hi'))
+    calls = conn.client.room_send.call_args_list
+    assert calls
+    for call in calls:
+        assert call.kwargs['ignore_unverified_devices'] is True
+
+
+def _keymgmt_client(sync, **flags):
+    """Fake client exposing the E2EE key-lifecycle surface."""
+    return SimpleNamespace(
+        sync=sync,
+        olm=object(),
+        should_upload_keys=flags.get('upload', False),
+        should_query_keys=flags.get('query', False),
+        keys_upload=AsyncMock(),
+        keys_query=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_listen_runs_key_maintenance_on_sync():
+    """A manual sync loop must drive keys_upload/keys_query like
+    sync_forever — otherwise the bot never obtains Megolm keys and every
+    encrypted message stays undecryptable, so echo never fires."""
+    conn, _ = make_connector()
+    conn.next_batch = 'old'  # not a first sync
+
+    async def fake_sync(timeout, since):
+        conn.running = False
+        return sync_response('new', [message_event(body='hi')])
+
+    client = _keymgmt_client(fake_sync, upload=True, query=True)
+    conn.client = client
+    conn.running = True
+    await conn.listen()
+
+    client.keys_upload.assert_awaited_once()
+    client.keys_query.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_key_maintenance_failure_does_not_break_loop():
+    """A failing key call is logged and swallowed; the sync loop and message
+    dispatch continue unaffected."""
+    conn, manager = make_connector()
+    conn.next_batch = 'old'
+
+    async def fake_sync(timeout, since):
+        conn.running = False
+        return sync_response('new', [message_event(body='hi')])
+
+    client = _keymgmt_client(fake_sync, upload=True)
+    client.keys_upload = AsyncMock(side_effect=RuntimeError('boom'))
+    conn.client = client
+    conn.running = True
+    await conn.listen()
+    assert manager.dispatch.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_plaintext_mode_skips_key_maintenance():
+    """No olm machine (plaintext-only) → no key calls and no AttributeError."""
+    conn, manager = make_connector()
+    conn.next_batch = 'old'
+
+    async def fake_sync(timeout, since):
+        conn.running = False
+        return sync_response('new', [message_event(body='hi')])
+
+    conn.client = SimpleNamespace(sync=fake_sync)  # no olm / should_* attrs
+    conn.running = True
+    await conn.listen()
+    assert manager.dispatch.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_sync_error_raises_after_max_failures():
     """Repeated transient sync errors (no next_batch) eventually mark the
     connector down — but only after SYNC_MAX_FAILURES retries, not on the

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -58,6 +58,25 @@ def test_activation_rules():
     assert Connector.is_active({}) is False
 
 
+def test_is_authorized():
+    conn, _ = make_connector()
+    conn.config['channels'] = ['!authorized:example.org']
+    conn.client = SimpleNamespace(rooms={
+        '!authorized:example.org': SimpleNamespace(users={'@a', '@b', '@c'}),
+        '!dm:example.org': SimpleNamespace(users={'@a', '@b'}),
+        '!unauthorized:example.org': SimpleNamespace(users={'@a', '@b', '@c'}),
+    })
+    
+    auth_env = Envelope('matrix', '@a', '!authorized:example.org', 'test')
+    assert conn.is_authorized(auth_env) is True
+    
+    dm_env = Envelope('matrix', '@a', '!dm:example.org', 'test')
+    assert conn.is_authorized(dm_env) is True
+    
+    unauth_env = Envelope('matrix', '@a', '!unauthorized:example.org', 'test')
+    assert conn.is_authorized(unauth_env) is False
+
+
 @pytest.mark.asyncio
 async def test_event_becomes_envelope():
     conn, manager = make_connector()

--- a/tests/test_xmpp.py
+++ b/tests/test_xmpp.py
@@ -24,6 +24,81 @@ async def test_xmpp_message():
     assert env.text == 'hello xmpp'
 
 @pytest.mark.asyncio
+async def test_xmpp_groupchat_message():
+    from iacecil.connectors.xmpp import XMPPBot
+    manager = AsyncMock()
+    connector = MagicMock()
+    connector.manager = manager
+    bot = XMPPBot('user@host', 'pw', connector)
+    # mock full jid string
+    bot.boundjid.full = 'user@host/res'
+    bot.boundjid.user = 'user'
+
+    msg = MagicMock()
+    def getitem(k):
+        if k == 'type': return 'groupchat'
+        if k == 'body': return 'hello muc'
+        if k == 'from': 
+            m = MagicMock()
+            m.bare = 'room@conf.host'
+            m.resource = 'other_user'
+            m.full = 'room@conf.host/other_user'
+            return m
+        return None
+    msg.__getitem__.side_effect = getitem
+
+    await bot.message(msg)
+
+    manager.dispatch.assert_called_once()
+    env = manager.dispatch.call_args[0][0]
+    assert env.platform == 'xmpp'
+    assert env.conversation_ref == 'room@conf.host'
+    assert env.text == 'hello muc'
+
+@pytest.mark.asyncio
+async def test_xmpp_ignore_own_groupchat_message():
+    from iacecil.connectors.xmpp import XMPPBot
+    manager = AsyncMock()
+    connector = MagicMock()
+    connector.manager = manager
+    bot = XMPPBot('user@host', 'pw', connector)
+    bot.boundjid.full = 'user@host/res'
+    bot.boundjid.user = 'user'
+
+    msg = MagicMock()
+    def getitem(k):
+        if k == 'type': return 'groupchat'
+        if k == 'from': 
+            m = MagicMock()
+            m.bare = 'room@conf.host'
+            m.resource = 'user'  # same as boundjid.user
+            m.full = 'room@conf.host/user'
+            return m
+        return None
+    msg.__getitem__.side_effect = getitem
+
+    await bot.message(msg)
+    manager.dispatch.assert_not_called()
+
+def test_xmpp_is_authorized():
+    from iacecil.connectors.xmpp import Connector
+    manager = MagicMock()
+    # authorized channels config
+    conn = Connector(manager, {'jid': 'user@host', 'password': 'pw', 'channels': ['room1@conf.host']})
+    
+    # DM is always authorized
+    env_dm = Envelope(platform='xmpp', sender_ref='user2@host', conversation_ref='user2@host', raw={'type': 'chat'}, text='hi')
+    assert conn.is_authorized(env_dm) is True
+    
+    # Authorized MUC
+    env_muc_auth = Envelope(platform='xmpp', sender_ref='room1@conf.host/user', conversation_ref='room1@conf.host', raw={'type': 'groupchat'}, text='hi')
+    assert conn.is_authorized(env_muc_auth) is True
+    
+    # Unauthorized MUC
+    env_muc_unauth = Envelope(platform='xmpp', sender_ref='room2@conf.host/user', conversation_ref='room2@conf.host', raw={'type': 'groupchat'}, text='hi')
+    assert conn.is_authorized(env_muc_unauth) is False
+
+@pytest.mark.asyncio
 async def test_xmpp_failure_marks_connector_down():
     from iacecil.connectors.xmpp import Connector, XMPPBot
     manager = MagicMock()

--- a/tests/test_xmpp.py
+++ b/tests/test_xmpp.py
@@ -80,6 +80,20 @@ async def test_xmpp_ignore_own_groupchat_message():
     await bot.message(msg)
     manager.dispatch.assert_not_called()
 
+@pytest.mark.asyncio
+async def test_xmpp_on_invite():
+    from iacecil.connectors.xmpp import XMPPBot
+    connector = MagicMock()
+    bot = XMPPBot('user@host', 'pw', connector)
+    bot.boundjid.user = 'user'
+    # Mock xep_0045 plugin
+    bot.plugin = {'xep_0045': MagicMock()}
+    
+    inv = {'from': 'room@conf.host', 'inviter': 'friend@host'}
+    await bot.on_invite(inv)
+    
+    bot.plugin['xep_0045'].join_muc.assert_called_once_with('room@conf.host', 'user')
+
 def test_xmpp_is_authorized():
     from iacecil.connectors.xmpp import Connector
     manager = MagicMock()


### PR DESCRIPTION
## Problem
Echo still didn't work in encrypted Matrix rooms after the prior E2EE fixes (dependency auto-detect, store dir, sync `load_store`, manual `decrypt_event`). Logs showed `Room <id> has an encrypted message that could not be decrypted`.

## Root cause
The connector drives its own `client.sync()` loop instead of `sync_forever()`, but never replicated the **key lifecycle** that `sync_forever()` runs internally. Without `keys_upload()` the bot's device + one-time keys are never published, so no sender can establish an Olm session to share a Megolm session key with it. Every encrypted event then arrives as an undecryptable `MegolmEvent`, `_on_event` sees `body=None`, and the echo default-handler is never reached. (Verified against `matrix-nio==0.25.2`: `sync_forever` runs `keys_upload`/`keys_query`; the manual loop ran neither.)

## Fix
- `connect()` — upload device keys after `load_store()` when `should_upload_keys`.
- `listen()` — replenish one-time keys / refresh device lists each successful sync; failures logged and swallowed so they can't break the loop or trip the backoff counter.
- `send()` — pass `ignore_unverified_devices=True` so a headless bot (no interactive verification) can deliver replies into encrypted rooms instead of raising `OlmUnverifiedDeviceError`.

All key calls are guarded by the olm machine's presence, so plaintext-only mode (no libolm) is unaffected.

## Tests
4 new tests in `tests/test_matrix.py` (key maintenance runs, failure isolation, plaintext skip, send flag). Full matrix suite: 20 passed.

## Notes
- Messages sent **before** the bot's first `keys_upload` remain undecryptable (no session key was ever shared) — expected, not a regression.
- Plan: `docs/plans/2026-06-16-004-fix-matrix-e2ee-key-lifecycle-plan.md`.

## Residual Review Findings
- ⚠️ medium · `tests/test_connector_conformance.py` · `test_echo_round_trip_contract[matrix|discord|xmpp]` fail on `main` (pre-existing, **not** introduced here). The `channels`/`is_authorized` feature (690ddf6) gates replies, and the conformance test never authorizes its `'chat'` conversation, so `is_authorized` returns `False` and `send` is never called. This is a test-setup gap spanning three connectors, not a runtime echo blocker (matrix authorizes DMs ≤2 members and configured channels once `client.rooms` is populated). Left out of this PR to keep scope to E2EE; worth a follow-up to either authorize the conformance conversation or decide the empty-`channels` default.
